### PR TITLE
Move process model examples to make the tests work

### DIFF
--- a/packages/synthchron-simulator/src/index.ts
+++ b/packages/synthchron-simulator/src/index.ts
@@ -1,4 +1,4 @@
-import { petriNet1 } from '../test/processModelExamples/petriNet';
+import { petriNet1 } from './processModelExamples/petriNet';
 import * as YAML from 'yaml';
 
 export const main = (): string => 'Hello World';

--- a/packages/synthchron-simulator/src/processModelExamples/flowchart.ts
+++ b/packages/synthchron-simulator/src/processModelExamples/flowchart.ts
@@ -1,4 +1,4 @@
-import { FlowchartProcessModel } from "../../src/types/processModelTypes/flowChart"
+import { FlowchartProcessModel } from "../types/processModelTypes/flowChart"
 
 export const flowchart1 = (): FlowchartProcessModel => ({
     type: "flowchart",

--- a/packages/synthchron-simulator/src/processModelExamples/petriNet.ts
+++ b/packages/synthchron-simulator/src/processModelExamples/petriNet.ts
@@ -1,4 +1,4 @@
-import { PetriNetProcessModel } from "../../src/types/processModelTypes/petriNetTypes"
+import { PetriNetProcessModel } from "../types/processModelTypes/petriNetTypes"
 
 export const petriNet1 = (): PetriNetProcessModel => ({
     type: "petri-net",


### PR DESCRIPTION
We previously had the examples together with the tests. This seems to stop the chai tests from worker. Unsure why but we therefore move the examples to the src/ directory.