### PR TITLE
Syn 155 add confirmation for switching tabs without saving

### DIFF
--- a/packages/synthchron-tauri/package.json
+++ b/packages/synthchron-tauri/package.json
@@ -58,6 +58,7 @@
     "@vitejs/plugin-react": "^4.0.0",
     "babel-loader": "^9.1.2",
     "eslint": "^8.37.0",
+    "lodash": "^4.17.21",
     "sass": "^1.60.0",
     "typescript": "^5.0.4",
     "vite": "^4.2.1"

--- a/packages/synthchron-tauri/src/Routing.tsx
+++ b/packages/synthchron-tauri/src/Routing.tsx
@@ -12,14 +12,8 @@ const router = createBrowserRouter([
     element: <MainMenuPage />,
   },
   {
-    path: 'editor',
+    path: 'editor/:projectId',
     element: <EditorPage />,
-    children: [
-      {
-        path: ':projectId',
-        element: <EditorPage />,
-      },
-    ],
   },
   {
     path: 'collaborate',

--- a/packages/synthchron-tauri/src/Routing.tsx
+++ b/packages/synthchron-tauri/src/Routing.tsx
@@ -1,4 +1,4 @@
-import { Route, Routes } from 'react-router-dom'
+import { RouterProvider, createBrowserRouter } from 'react-router-dom'
 
 import { Debug } from './components/Debug'
 import { CollaborationPage } from './pages/CollaborationPage'
@@ -6,18 +6,33 @@ import { EditorPage } from './pages/EditorPage'
 import { MainMenuPage } from './pages/MainMenuPage'
 import { NotFoundPage } from './pages/NotFoundPage'
 
-export const Routing: React.FC = () => {
-  return (
-    <Routes>
-      <Route index element={<MainMenuPage />} />
-      <Route path='editor/' element={<EditorPage />}>
-        <Route path=':projectId/' element={<EditorPage />} />
-      </Route>
-      <Route path='collaborate/' element={<CollaborationPage />}>
-        <Route path=':roomId/' element={<CollaborationPage />} />
-      </Route>
-      <Route path='debug/' element={<Debug />} />
-      <Route path='*' element={<NotFoundPage />} />
-    </Routes>
-  )
-}
+const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <MainMenuPage />,
+  },
+  {
+    path: 'editor',
+    element: <EditorPage />,
+    children: [
+      {
+        path: ':projectId',
+        element: <EditorPage />,
+      },
+    ],
+  },
+  {
+    path: 'collaborate',
+    element: <CollaborationPage />,
+  },
+  {
+    path: 'debug',
+    element: <Debug />,
+  },
+  {
+    path: '*',
+    element: <NotFoundPage />,
+  },
+])
+
+export const Routing: React.FC = () => <RouterProvider router={router} />

--- a/packages/synthchron-tauri/src/components/CustomAppBar.tsx
+++ b/packages/synthchron-tauri/src/components/CustomAppBar.tsx
@@ -31,8 +31,8 @@ export const CustomAppBar: React.FC = () => {
       href: '/',
     },
     {
-      name: 'Debug',
-      href: '/debug',
+      name: 'Collaborate',
+      href: '/collaborate',
     },
   ]
 
@@ -152,10 +152,10 @@ export const CustomAppBar: React.FC = () => {
               color: 'white',
               display: 'block',
             }}
-            to={'/collaborate'}
+            to={'/debug'}
             component={Link}
           >
-            Collaborate
+            Debug
           </Button>
         </Toolbar>
       </Container>

--- a/packages/synthchron-tauri/src/components/CustomAppBar.tsx
+++ b/packages/synthchron-tauri/src/components/CustomAppBar.tsx
@@ -61,7 +61,6 @@ export const CustomAppBar: React.FC = () => {
       <Container maxWidth='xl'>
         <Toolbar variant='dense' disableGutters>
           <AccountTreeRoundedIcon sx={{ mr: 1 }} />
-          {/* <AdbIcon sx={{ display: { xs: 'none', md: 'flex' }, mr: 1 }} /> */}
           <Typography
             variant='h6'
             noWrap

--- a/packages/synthchron-tauri/src/components/CustomAppBar.tsx
+++ b/packages/synthchron-tauri/src/components/CustomAppBar.tsx
@@ -16,14 +16,17 @@ import { Link } from 'react-router-dom'
 
 import NewProjectModal from './NewProjectModal'
 import { usePersistentStore } from './common/persistentStore'
+import { useEditorStore } from './editor/editorStore/flowStore'
 
 const RECENT_PROJECTS_LIMIT = 5 // number of projects to show in the recent projects list
-const RECENT_PROJECTS_TIMEOUT = 60 * 60 * 1000 // time in milliseconds that projects are still considered recent
+//const RECENT_PROJECTS_TIMEOUT = 60 * 60 * 1000 // time in milliseconds that projects are still considered recent
 
 export const CustomAppBar: React.FC = () => {
   const [isNewProjectModalOpen, setNewProjectModalOpen] = useState(false)
 
   const projects = usePersistentStore((state) => state.projects)
+
+  const sessionStart = useEditorStore((state) => state.sessionStart)
 
   const pages = [
     {
@@ -39,11 +42,9 @@ export const CustomAppBar: React.FC = () => {
   const projectButtons = Object.entries(projects)
     .sort(
       ([_key1, x], [_key2, y]) =>
-        -(Date.parse(x.lastEdited) - Date.parse(y.lastEdited))
+        -(Date.parse(x.lastOpened) - Date.parse(y.lastOpened))
     )
-    .filter(
-      ([, y]) => Date.now() - Date.parse(y.lastEdited) < RECENT_PROJECTS_TIMEOUT
-    )
+    .filter(([, y]) => sessionStart < Date.parse(y.lastOpened))
     .slice(0, RECENT_PROJECTS_LIMIT)
     .map(([x, y]) => ({
       name: y.projectName.slice(0, 25),

--- a/packages/synthchron-tauri/src/components/NewProjectModal.tsx
+++ b/packages/synthchron-tauri/src/components/NewProjectModal.tsx
@@ -157,6 +157,7 @@ const NewProjectModal: React.FC<NewProjectModalProps> = ({
       projectModel: model, // TODO
       created: new Date().toJSON(),
       lastEdited: new Date().toJSON(),
+      lastOpened: (redirect ? new Date() : new Date(0)).toJSON(),
     })
     setNewProjectConfig(newProjectDefault())
     if (redirect) navigate(`/editor/${projectId}`)

--- a/packages/synthchron-tauri/src/components/ProjectCard.tsx
+++ b/packages/synthchron-tauri/src/components/ProjectCard.tsx
@@ -6,6 +6,7 @@ import {
   Typography,
 } from '@mui/material'
 import moment from 'moment'
+import { Link } from 'react-router-dom'
 
 import { Project } from '../types/project'
 import { usePersistentStore } from './common/persistentStore'
@@ -20,6 +21,8 @@ export const ProjectCard: React.FC<ProjectCardProps> = ({
   projectId,
 }) => {
   const removeProject = usePersistentStore((state) => state.removeProject)
+
+  const updateProject = usePersistentStore((state) => state.updateProject)
 
   return (
     <Card sx={{ minWidth: 275 }}>
@@ -60,7 +63,17 @@ export const ProjectCard: React.FC<ProjectCardProps> = ({
           alignSelf: 'flex-end',
         }}
       >
-        <Button href={`/editor/${projectId}`}>Edit</Button>
+        <Button
+          to={`/editor/${projectId}`}
+          component={Link}
+          onClick={() => {
+            updateProject(projectId, {
+              lastOpened: new Date().toJSON(),
+            })
+          }}
+        >
+          Edit
+        </Button>
         <Button onClick={() => alert('Not implemented')}>Clone</Button>
         <Button onClick={() => removeProject(projectId)} color='error'>
           Delete

--- a/packages/synthchron-tauri/src/components/editor/LeftSidebar.tsx
+++ b/packages/synthchron-tauri/src/components/editor/LeftSidebar.tsx
@@ -3,46 +3,10 @@ import { CollaborationTab } from './leftSidebar/CollaborationTab'
 import { CreatorTab } from './leftSidebar/CreatorTab'
 import { ProjectTab } from './leftSidebar/ProjectTab'
 
-export const LeftSidebar = () => {
-  // This code should be kept but not here
-  /* const transformTest = () => {
-    console.log(transformFlowToSimulator(useFlowStore.getState()))
-  }
-  const simulate = () => {
-    console.log(
-      simulateWithEngine(
-        transformFlowToSimulator(
-          useFlowStore.getState()
-        ) as PetriNetProcessModel,
-        { endOnAcceptingState: true, minEvents: 1, maxEvents: 100 },
-        petriNetEngine
-      )
-    )
-  } */
-
-  return (
-    <>
-      <TabbedDrawer side='left' tabs={['Project', 'Creator', 'Collab']}>
-        <ProjectTab />
-        <CreatorTab />
-        <CollaborationTab />
-      </TabbedDrawer>
-    </>
-  )
-  /* <aside>
-      <Button onClick={transformTest}> Transform </Button>
-      
-      <Button
-        onClick={() => {
-          if (projectId) {
-            saveFlow(projectId)
-          } else {
-            console.log('No project id') // TODO: Create project
-          }
-        }}
-      >
-        Save
-      </Button>
-      <Button onClick={simulate}>Simulate</Button>
-    </aside> */
-}
+export const LeftSidebar = () => (
+  <TabbedDrawer side='left' tabs={['Project', 'Creator', 'Collab']}>
+    <ProjectTab />
+    <CreatorTab />
+    <CollaborationTab />
+  </TabbedDrawer>
+)

--- a/packages/synthchron-tauri/src/components/editor/editorStore/editorSlice.ts
+++ b/packages/synthchron-tauri/src/components/editor/editorStore/editorSlice.ts
@@ -7,6 +7,7 @@ import { EditorState } from './flowStore'
 
 export type EditorSlice = {
   saveFlow: (id: string) => void
+  getProcessModel: () => ProcessModel
 }
 
 export const createEditorSlice: StateCreator<
@@ -16,13 +17,15 @@ export const createEditorSlice: StateCreator<
   EditorSlice
 > = (set, get) => ({
   saveFlow: (id: string) => {
-    const processModel: ProcessModel = get().processModelFlowConfig.serialize(
+    usePersistentStore.getState().updateProject(id, {
+      projectModel: get().getProcessModel(),
+    })
+    set({ unsavedChanges: false })
+  },
+  getProcessModel: () =>
+    get().processModelFlowConfig.serialize(
       get().nodes,
       get().edges,
       get().meta
-    )
-    usePersistentStore.getState().updateProject(id, {
-      projectModel: processModel,
-    })
-  },
+    ),
 })

--- a/packages/synthchron-tauri/src/components/editor/editorStore/editorSlice.ts
+++ b/packages/synthchron-tauri/src/components/editor/editorStore/editorSlice.ts
@@ -6,8 +6,11 @@ import { usePersistentStore } from '../../common/persistentStore'
 import { EditorState } from './flowStore'
 
 export type EditorSlice = {
-  saveFlow: (id: string) => void
+  saveFlow: () => void
   getProcessModel: () => ProcessModel
+  projectId: string | undefined
+  setProjectId: (id: string) => void
+  sessionStart: number
 }
 
 export const createEditorSlice: StateCreator<
@@ -15,9 +18,11 @@ export const createEditorSlice: StateCreator<
   [],
   [],
   EditorSlice
-> = (_set, get) => ({
-  saveFlow: (id: string) => {
-    usePersistentStore.getState().updateProject(id, {
+> = (set, get) => ({
+  saveFlow: async () => {
+    const projectId = get().projectId
+    if (projectId === undefined) return
+    usePersistentStore.getState().updateProject(projectId, {
       projectModel: get().getProcessModel(),
     })
   },
@@ -27,4 +32,9 @@ export const createEditorSlice: StateCreator<
       get().edges,
       get().meta
     ),
+  projectId: undefined,
+  setProjectId: (id: string) => {
+    set({ projectId: id })
+  },
+  sessionStart: new Date().getTime(),
 })

--- a/packages/synthchron-tauri/src/components/editor/editorStore/editorSlice.ts
+++ b/packages/synthchron-tauri/src/components/editor/editorStore/editorSlice.ts
@@ -15,12 +15,11 @@ export const createEditorSlice: StateCreator<
   [],
   [],
   EditorSlice
-> = (set, get) => ({
+> = (_set, get) => ({
   saveFlow: (id: string) => {
     usePersistentStore.getState().updateProject(id, {
       projectModel: get().getProcessModel(),
     })
-    set({ unsavedChanges: false })
   },
   getProcessModel: () =>
     get().processModelFlowConfig.serialize(

--- a/packages/synthchron-tauri/src/components/editor/editorStore/flowStore.ts
+++ b/packages/synthchron-tauri/src/components/editor/editorStore/flowStore.ts
@@ -20,25 +20,31 @@ export type EditorState = YjsSlice &
       nodes: Node[],
       edges: Edge[],
       meta: object,
-      config: ProcessModelFlowConfig
+      config: ProcessModelFlowConfig,
+      projectId: string
     ) => void
   }
 
 // this is our useStore hook that we can use in our components to get parts of the store and call actions
-export const useEditorStore = create<EditorState>((...args) => ({
+export const useEditorStore = create<EditorState>((set, get, api) => ({
   // YDoc state for collaboration
-  ...createYjsSlice(...args), // CRDT relevant state
-  ...createFlowSlice(...args), // React Flow relevant state
-  ...createModelSlice(...args), // Process model relevant state
-  ...createEditorSlice(...args), // Editor relevant state
+  ...createYjsSlice(set, get, api), // CRDT relevant state
+  ...createFlowSlice(set, get, api), // React Flow relevant state
+  ...createModelSlice(set, get, api), // Process model relevant state
+  ...createEditorSlice(set, get, api), // Editor relevant state
 
   // Initialize the editor state by setting the yDoc. The yDoc will then propagate changes to the other state variables.
   initializeFlow: (
     nodes: Node[],
     edges: Edge[],
     meta: object,
-    config: ProcessModelFlowConfig
+    config: ProcessModelFlowConfig,
+    projectId: string
   ) => {
+    get().saveFlow()
+    useEditorStore.setState({
+      projectId,
+    })
     yDoc.destroy()
     yDocState.nodesMap.clear()
     nodes.forEach((node) => {

--- a/packages/synthchron-tauri/src/components/editor/editorStore/flowStore.ts
+++ b/packages/synthchron-tauri/src/components/editor/editorStore/flowStore.ts
@@ -41,7 +41,7 @@ export const useEditorStore = create<EditorState>((set, get, api) => ({
     config: ProcessModelFlowConfig,
     projectId: string
   ) => {
-    get().saveFlow()
+    get().saveFlow() // This autosaved in case we switch projects
     useEditorStore.setState({
       projectId,
     })

--- a/packages/synthchron-tauri/src/components/editor/leftSidebar/ProjectTab.tsx
+++ b/packages/synthchron-tauri/src/components/editor/leftSidebar/ProjectTab.tsx
@@ -90,7 +90,7 @@ export const ProjectTab: React.FC = () => {
         <Button
           onClick={() => {
             if (projectId) {
-              saveFlow(projectId)
+              saveFlow()
             } else {
               const processModel = transformFlowToSimulator(
                 useEditorStore.getState()
@@ -101,6 +101,7 @@ export const ProjectTab: React.FC = () => {
                 projectModel: processModel,
                 created: new Date().toJSON(),
                 lastEdited: new Date().toJSON(),
+                lastOpened: new Date(0).toJSON(),
               })
 
               navigate(`/editor/${id}`)

--- a/packages/synthchron-tauri/src/components/editor/processModels/petriNet/petriNetFlowConfig.ts
+++ b/packages/synthchron-tauri/src/components/editor/processModels/petriNet/petriNetFlowConfig.ts
@@ -100,7 +100,6 @@ export const petriNetFlowConfig: ProcessModelFlowConfig = {
           identifier,
           type,
           name,
-          accepting: node.data.accepting,
           amountOfTokens: node.data.tokens,
           position: node.position,
         } as PetriNetPlace

--- a/packages/synthchron-tauri/src/main.tsx
+++ b/packages/synthchron-tauri/src/main.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import ReactDOM from 'react-dom/client'
-import { BrowserRouter } from 'react-router-dom'
+import { BrowserRouter, RouterProvider } from 'react-router-dom'
 
 import { Routing } from './Routing'
 import './style.css'
@@ -13,8 +13,6 @@ import '@fontsource/roboto/700.css'
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <BrowserRouter>
-      <Routing />
-    </BrowserRouter>
+    <Routing />
   </React.StrictMode>
 )

--- a/packages/synthchron-tauri/src/main.tsx
+++ b/packages/synthchron-tauri/src/main.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 
 import ReactDOM from 'react-dom/client'
-import { BrowserRouter, RouterProvider } from 'react-router-dom'
 
 import { Routing } from './Routing'
 import './style.css'

--- a/packages/synthchron-tauri/src/pages/EditorPage.tsx
+++ b/packages/synthchron-tauri/src/pages/EditorPage.tsx
@@ -1,8 +1,9 @@
 import { useEffect } from 'react'
 
 import { Alert, Box, Snackbar } from '@mui/material'
+import _ from 'lodash'
 import { useHotkeys } from 'react-hotkeys-hook'
-import { useParams } from 'react-router-dom'
+import { unstable_usePrompt, useParams } from 'react-router-dom'
 
 import { CustomAppBar } from '../components/CustomAppBar'
 import { usePersistentStore } from '../components/common/persistentStore'
@@ -18,6 +19,19 @@ export const EditorPage = () => {
 
   const initializeFlow = useEditorStore((state) => state.initializeFlow)
   const saveFlow = useEditorStore((state) => state.saveFlow)
+  const getProcessModel = useEditorStore((state) => state.getProcessModel)
+
+  unstable_usePrompt({
+    // The following lines are needed because the types for unstable_usePrompt are wrong.
+    // They claim to only take a boolean, but can actually take a function that returns a boolean.
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    when: () =>
+      projectId !== undefined &&
+      !_.isEqual(projects[projectId].projectModel, getProcessModel()),
+    message: 'You have unsaved changes, are you sure you want to leave?',
+  })
 
   useHotkeys(
     'ctrl+s',

--- a/packages/synthchron-tauri/src/pages/EditorPage.tsx
+++ b/packages/synthchron-tauri/src/pages/EditorPage.tsx
@@ -3,7 +3,7 @@ import { useEffect } from 'react'
 import { Alert, Box, Snackbar } from '@mui/material'
 import _ from 'lodash'
 import { useHotkeys } from 'react-hotkeys-hook'
-import { unstable_usePrompt, useParams } from 'react-router-dom'
+import { useParams } from 'react-router-dom'
 
 import { CustomAppBar } from '../components/CustomAppBar'
 import { usePersistentStore } from '../components/common/persistentStore'
@@ -19,26 +19,13 @@ export const EditorPage = () => {
 
   const initializeFlow = useEditorStore((state) => state.initializeFlow)
   const saveFlow = useEditorStore((state) => state.saveFlow)
-  const getProcessModel = useEditorStore((state) => state.getProcessModel)
-
-  unstable_usePrompt({
-    // The following lines are needed because the types for unstable_usePrompt are wrong.
-    // They claim to only take a boolean, but can actually take a function that returns a boolean.
-
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    when: () =>
-      projectId !== undefined &&
-      !_.isEqual(projects[projectId].projectModel, getProcessModel()),
-    message: 'You have unsaved changes, are you sure you want to leave?',
-  })
 
   useHotkeys(
     'ctrl+s',
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (event: any) => {
       event.preventDefault()
-      if (projectId !== undefined) saveFlow(projectId)
+      if (projectId !== undefined) saveFlow()
     },
     [saveFlow, projectId]
   )
@@ -49,7 +36,7 @@ export const EditorPage = () => {
     const { nodes, edges, meta } = processModelConfig.generateFlow(
       projects[projectId].projectModel
     )
-    initializeFlow(nodes, edges, meta, processModelConfig)
+    initializeFlow(nodes, edges, meta, processModelConfig, projectId)
   }, [projectId])
 
   return (

--- a/packages/synthchron-tauri/src/pages/EditorPage.tsx
+++ b/packages/synthchron-tauri/src/pages/EditorPage.tsx
@@ -62,7 +62,21 @@ export const EditorPage = () => {
       }}
     >
       <CustomAppBar />
-      <SidebarsWrapper />
+      {projectId !== undefined && projects[projectId] === undefined ? (
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'center',
+            alignItems: 'center',
+            flexGrow: 1,
+          }}
+        >
+          <Alert severity='error'>Project with id {projectId} not found</Alert>
+        </Box>
+      ) : (
+        <SidebarsWrapper />
+      )}
       <Snackbar
         open={open}
         autoHideDuration={1000}

--- a/packages/synthchron-tauri/src/types/project.ts
+++ b/packages/synthchron-tauri/src/types/project.ts
@@ -15,4 +15,7 @@ export type Project = {
 
   // When the data has last been saved
   lastEdited: string
+
+  // When the project was last opened
+  lastOpened: string
 }


### PR DESCRIPTION
## Describe your changes

- Adds autosave for models
- In case autosave fails, prompts the user for unsaved changes
- Reorders tabs, and only includes tabs from the current session

## Checklist before requesting a review
- [x] I have performed a self-review of my code
